### PR TITLE
Fix: enforce signing of release RPM artifacts

### DIFF
--- a/.github/workflows/rpm-release.yml
+++ b/.github/workflows/rpm-release.yml
@@ -56,6 +56,69 @@ jobs:
             --output-dir dist/rpm \
             --signing-key-id "$RPM_SIGNING_KEY_ID"
 
+      - name: Ensure RPMs are signed
+        shell: bash
+        env:
+          RPM_SIGNING_KEY_BASE64: ${{ secrets.RPM_SIGNING_KEY_BASE64 }}
+          RPM_SIGNING_KEY_ID: ${{ secrets.RPM_SIGNING_KEY_ID }}
+          RPM_SIGNING_PASSPHRASE: ${{ secrets.RPM_SIGNING_PASSPHRASE }}
+        run: |
+          set -euxo pipefail
+          if [[ -z "${RPM_SIGNING_KEY_ID:-}" ]]; then
+            echo "RPM signing key ID must be provided" >&2
+            exit 1
+          fi
+          if [[ -z "${RPM_SIGNING_KEY_BASE64:-}" ]]; then
+            echo "Base64-encoded signing key material is required" >&2
+            exit 1
+          fi
+
+          GNUPGHOME="$(mktemp -d)"
+          chmod 700 "$GNUPGHOME"
+          export GNUPGHOME
+
+          cleanup() {
+            rm -rf "$GNUPGHOME"
+            [[ -n "${PASS_FILE:-}" && -f "$PASS_FILE" ]] && rm -f "$PASS_FILE"
+            [[ -n "${MACROS_FILE:-}" && -f "$MACROS_FILE" ]] && rm -f "$MACROS_FILE"
+          }
+          trap cleanup EXIT
+
+          printf '%s' "$RPM_SIGNING_KEY_BASE64" | base64 --decode | gpg --batch --import
+          gpg --batch --list-secret-keys "$RPM_SIGNING_KEY_ID" >/dev/null
+
+          PASS_MACRO=""
+          if [[ -n "${RPM_SIGNING_PASSPHRASE:-}" ]]; then
+            PASS_FILE="$(mktemp)"
+            printf '%s' "$RPM_SIGNING_PASSPHRASE" >"$PASS_FILE"
+            PASS_MACRO="--passphrase-file $PASS_FILE"
+          fi
+
+          MACROS_FILE="$(mktemp)"
+          cat >"$MACROS_FILE" <<EOF
+%_signature gpg
+%_gpg_name ${RPM_SIGNING_KEY_ID}
+%_gpg_path ${GNUPGHOME}
+%__gpg gpg
+%__gpg_sign_cmd %{__gpg} --batch --pinentry-mode loopback ${PASS_MACRO} --no-armor --detach-sign --sign %{-u*} %{-s*} %{__signdata}
+EOF
+
+          mapfile -t RPM_FILES < <(find dist/rpm -type f -name '*.rpm' -print)
+          if [[ "${#RPM_FILES[@]}" -eq 0 ]]; then
+            echo "No RPMs found to sign" >&2
+            exit 1
+          fi
+
+          for rpm_path in "${RPM_FILES[@]}"; do
+            if rpm --checksig "$rpm_path" | grep -qiE 'pgp|signature(s)? OK'; then
+              echo "Already signed: $(basename "$rpm_path")"
+              continue
+            fi
+            echo "Signing $(basename "$rpm_path")"
+            rpmsign --macros "$MACROS_FILE" --addsign "$rpm_path"
+            rpm --checksig "$rpm_path"
+          done
+
       - name: rpmlint
         run: |
           set -euxo pipefail


### PR DESCRIPTION
## Summary
- import the GPG signing key during the release build and re-sign any unsigned RPM artifacts before publishing
- add early checks so the workflow fails if signing secrets are not available

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68e60d3c9aa8832384ed9124b64d2730